### PR TITLE
Remove `chruby <ruby>` from profile.d if default attr is nil.

### DIFF
--- a/templates/default/chruby.sh.erb
+++ b/templates/default/chruby.sh.erb
@@ -14,6 +14,6 @@ RUBIES+=($HOME/.rbenv/rubies/*)
 
 <% if ::File.exists?("/opt/chef/embedded") and node['chruby']['default'] == "embedded" -%>
 chruby embedded
-<% else -%>
+<% elsif node['chruby']['default'] -%>
 chruby <%= node['chruby']['default'] %>
 <% end -%>


### PR DESCRIPTION
I've found a couple of use cases where I'd rather not have a `chuby` exec in `/etc/profile.d/chruby.sh`, namely each user having their own separate default Ruby version. This commit will simply skip the line in the `chruby.sh` script when `node['chruby']['default']` is `nil` or `false`.
