### PR TITLE
Fix for issue #10

### DIFF
--- a/templates/default/chruby.sh.erb
+++ b/templates/default/chruby.sh.erb
@@ -1,5 +1,5 @@
 source /usr/local/chruby/share/chruby/chruby.sh
-<%= node['chruby']['auto_switch'] && "source /usr/local/chruby/share/chruby/auto.sh" %>
+
 <% if ::File.exists?("/opt/chef/embedded") -%>
 RUBIES+=(/opt/chef/embedded)
 <% end -%>
@@ -17,3 +17,6 @@ chruby embedded
 <% elsif node['chruby']['default'] -%>
 chruby <%= node['chruby']['default'] %>
 <% end -%>
+
+<%= node['chruby']['auto_switch'] && "source /usr/local/chruby/share/chruby/auto.sh" %>
+


### PR DESCRIPTION
This seems to fix the problem of new sessions using embedded ruby rather than the version specified in .ruby-version (issue #10) by loading auto.sh after the chruby embedded call.
