### PR TITLE
Adds some flexibility to the generated chruby.sh file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,3 +6,5 @@ default['chruby']['auto_switch'] = true
 default['chruby']['rubies'] = {'1.9.3-p392' => true}
 default['chruby']['default'] = 'embedded'
 default['chruby']['user_rubies'] = {}
+default['chruby']['sh_dir'] = "/etc/profile.d"
+default['chruby']['sh_name'] = 'chruby.sh'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,14 +26,18 @@ end
 # Workaround for Github issue 5 https://github.com/Atalanta/chef-chruby/issues/5
 
 link "/usr/local/chruby" do
-  to "/usr/local/chruby-1" 
-end 
-
-directory "/etc/profile.d" do
-  recursive true
+  to "/usr/local/chruby-1"
 end
 
-template "/etc/profile.d/chruby.sh" do
+sh_owner = node['chruby']['sh_owner']
+
+directory node['chruby']['sh_dir'] do
+  recursive true
+  owner sh_owner if sh_owner
+end
+
+template File.join(node['chruby']['sh_dir'], node['chruby']['sh_name']) do
   source "chruby.sh.erb"
   mode "0644"
+  owner sh_owner if sh_owner
 end


### PR DESCRIPTION
The patch allows the user to override where the generated chruby.sh will be stored and who the owner of the file will be.
