### PR TITLE
Only set up chruby if the shell is bash or zsh

### DIFF
--- a/templates/default/chruby.sh.erb
+++ b/templates/default/chruby.sh.erb
@@ -1,3 +1,5 @@
+[ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ] || return
+
 source /usr/local/chruby/share/chruby/chruby.sh
 
 <% if ::File.exists?("/opt/chef/embedded") -%>


### PR DESCRIPTION
This fixes desktop logins on Ubuntu 13.10, described in https://github.com/postmodern/chruby/issues/56
