### PR TITLE
Allow specifying custom rubies path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Ensure you set an explicit dependency on the `chruby` cookbook if you are using 
 - `node['chruby']['auto_switch']` - enable automatic switching between Ruby versions per https://github.com/postmodern/chruby#auto-switching
 - `node['chruby']['rubies']` - an hash of Rubies / Booleans values to install using the `ruby-build` LWRP, and make available to chruby.
 - `node['chruby']['default']` - specify the default Ruby version for every shell.
- 
+- `node['chruby']['user_rubies']` - an array of directories containing custom rubies
+
 # Recipes
 
 ## Default
@@ -77,7 +78,7 @@ Builds and makes available the Ruby versions listed in the `node['chruby']['rubi
 
 - Author: Stephen Nelson-Smith (LordCope) - Atalanta Systems Ltd (<cookbooks@atalanta-systems.com>)
 
-Copyright 2013, Atalanta Systems Ltd 
+Copyright 2013, Atalanta Systems Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,6 @@ default['chruby']['use_rbenv_rubies'] = false
 default['chruby']['auto_switch'] = true
 default['chruby']['rubies'] = {'1.9.3-p392' => true}
 default['chruby']['default'] = 'embedded'
-default['chruby']['user_rubies'] = {}
+default['chruby']['user_rubies'] = []
 default['chruby']['sh_dir'] = "/etc/profile.d"
 default['chruby']['sh_name'] = 'chruby.sh'

--- a/templates/default/chruby.sh.erb
+++ b/templates/default/chruby.sh.erb
@@ -12,6 +12,10 @@ RUBIES+=($HOME/.rvm/rubies/*)
 RUBIES+=($HOME/.rbenv/rubies/*)
 <% end -%>
 
+<% node['chruby']['user_rubies'].each do |directory| -%>
+RUBIES+=(<%= directory.sub(/\/\z/, '') %>/*)
+<% end -%>
+
 <% if ::File.exists?("/opt/chef/embedded") and node['chruby']['default'] == "embedded" -%>
 chruby embedded
 <% elsif node['chruby']['default'] -%>


### PR DESCRIPTION
@Atalanta and @LordCope for review
# Problem

For people using custom ruby paths there is no way to specify a specific directory to look for rubies in.
# Solution

Using `node['chruby']['user_rubies']` array for custom paths. This attribute is optional and defaults to `[]`.
## Usage

Simply add the array to your role attributes.

For example:

```
default_attributes({
  'chruby' => {
    ,,,
    ,,,
    'user_rubies': [ '/usr/lib/custom_path' ]
  }
})
```

I've updated the attributes list in the README to indicate this.
