### PR TITLE
ensure version and checksum constraints for `ark`

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
-default['chruby']['version'] = '0.3.4'
+default['chruby']['version'] = '0.3.8'
+default['chruby']['checksum'] = 'd980872cf2cd047bc9dba78c4b72684c046e246c0fca5ea6509cae7b1ada63be'
 default['chruby']['gpg_check'] = false
 default['chruby']['use_rvm_rubies'] = false
 default['chruby']['use_rbenv_rubies'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,8 @@ include_recipe "ark"
 
 ark "chruby" do
   url "https://github.com/postmodern/chruby/archive/v#{node['chruby']['version']}.tar.gz"
+  version node['chruby']['version']
+  checksum node['chruby']['checksum']
   action :install_with_make
 end
 


### PR DESCRIPTION
- this also bumps the chruby version to the latest available and adds the checksum to match
