### PR TITLE
Fix `use_*(_rubies)` attribute calls in chruby.sh

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,9 +3,10 @@ maintainer       "Atalanta Systems Ltd"
 maintainer_email "support@atalanta-systems.com"
 license          "Apache 2.0"
 description      "Installs/Configures chruby"
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "0.2.1"
-depends		 "ark"
-depends		 "ruby_build"
-supports	 "centos"
-supports	 "ubuntu"
+
+depends  "ark"
+depends  "ruby_build"
+supports "centos"
+supports "ubuntu"

--- a/recipes/system.rb
+++ b/recipes/system.rb
@@ -18,7 +18,7 @@ node['chruby']['rubies'].each do |ruby, flag|
   if flag
     ruby_build_ruby ruby do
       prefix_path "/opt/rubies/#{ruby}"
-    end   
+    end
   end
 end
 

--- a/templates/default/chruby.sh.erb
+++ b/templates/default/chruby.sh.erb
@@ -4,11 +4,11 @@ source /usr/local/chruby/share/chruby/chruby.sh
 RUBIES+=(/opt/chef/embedded)
 <% end -%>
 
-<% if node['chruby']['use_rvm'] && ! Dir["~/.rubies/*"].empty? -%>
+<% if node['chruby']['use_rvm_rubies'] && ! Dir["~/.rubies/*"].empty? -%>
 RUBIES+=($HOME/.rvm/rubies/*)
 <% end -%>
 
-<% if node['chruby']['use_rbenv'] && ! Dir["~/.rbenv/versions/*"].empty? -%>
+<% if node['chruby']['use_rbenv_rubies'] && ! Dir["~/.rbenv/versions/*"].empty? -%>
 RUBIES+=($HOME/.rbenv/rubies/*)
 <% end -%>
 
@@ -23,4 +23,3 @@ chruby <%= node['chruby']['default'] %>
 <% end -%>
 
 <%= node['chruby']['auto_switch'] && "source /usr/local/chruby/share/chruby/auto.sh" %>
-


### PR DESCRIPTION
The defined default attributes are `use_*_rubies`, but those actually checked were `use_*`.

I also fixed general style consistency issues in the files I've visited. Spacing vs. tabs, indentation, etc. Small stuff.
