### PR TITLE
getting rid of redirect for remote file

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,8 @@
 include_recipe "ark"
 
 ark "chruby" do
-  url "https://github.com/postmodern/chruby/archive/v#{node['chruby']['version']}.tar.gz"
+  url "https://codeload.github.com/postmodern/chruby/tar.gz/v#{node['chruby']['version']}"
+  extension "tar.gz"
   action :install_with_make
 end
 


### PR DESCRIPTION
For some reason I was consistently hitting the redirect limit with chef 11.10.4 even though there was only 1 redirect. This change gets rid of that 1 redirect.
