### PR TITLE
Use git to download and install chruby

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
-default['chruby']['version'] = '0.3.4'
+default['chruby']['version'] = '0.3.8'
+default['chruby']['git_url'] = 'https://github.com/postmodern/chruby.git'
 default['chruby']['gpg_check'] = false
 default['chruby']['use_rvm_rubies'] = false
 default['chruby']['use_rbenv_rubies'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          "Apache 2.0"
 description      "Installs/Configures chruby"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.1"
-depends		 "ark"
+depends		 "git"
 depends		 "ruby_build"
 supports	 "centos"
 supports	 "ubuntu"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,17 +16,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe "ark"
+repo_path = "#{Chef::Config["file_cache_path"]}/chruby"
+execute "Install chruby" do
+  cwd repo_path
+  command %{sudo make install}
 
-ark "chruby" do
-  url "https://github.com/postmodern/chruby/archive/v#{node['chruby']['version']}.tar.gz"
-  action :install_with_make
+  action :nothing
 end
 
-# Workaround for Github issue 5 https://github.com/Atalanta/chef-chruby/issues/5
+git repo_path do
+  repository node["chruby"]["git_url"]
+  reference "v#{node["chruby"]["version"]}"
 
-link "/usr/local/chruby" do
-  to "/usr/local/chruby-1"
+  action :sync
+
+  notifies :run, resources(execute: "Install chruby"), :immediately
 end
 
 sh_owner = node['chruby']['sh_owner']

--- a/templates/default/chruby.sh.erb
+++ b/templates/default/chruby.sh.erb
@@ -1,4 +1,4 @@
-source /usr/local/chruby/share/chruby/chruby.sh
+source /usr/local/share/chruby/chruby.sh
 
 <% if ::File.exists?("/opt/chef/embedded") -%>
 RUBIES+=(/opt/chef/embedded)
@@ -22,5 +22,4 @@ chruby embedded
 chruby <%= node['chruby']['default'] %>
 <% end -%>
 
-<%= node['chruby']['auto_switch'] && "source /usr/local/chruby/share/chruby/auto.sh" %>
-
+<%= node['chruby']['auto_switch'] && "source /usr/local/share/chruby/auto.sh" %>


### PR DESCRIPTION
Use git to download the chruby repo (from any (forked) repo) and install.

Downside to this is that we can't verify the download anymore, but that wasn't be done anyway.

Another approach would be to use [remote_file](http://docs.opscode.com/resource_remote_file.html). That way we can drop the dependency for ark as well. We'd have to link to the direct `https://codeload.github.com/postmodern/chruby/tar.gz/v#{node['chruby']['version']}` download and install like the nginx cookbook does for example.
See downloading [here](https://github.com/opscode-cookbooks/nginx/blob/master/recipes/source.rb#L58), extracting [here](https://github.com/opscode-cookbooks/nginx/blob/master/recipes/source.rb#L82) and installing [here](https://github.com/opscode-cookbooks/nginx/blob/master/recipes/source.rb#L97).

Downside to this is not being able to select specific non-released version of chruby, although I doubt one should really be able to install them, they are not released for a reason.

Let me know what approach we should take.

More permanent fix for #19
