### PR TITLE
More direct download url to fix Chef::Exceptions::RedirectLimitExceeded

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,8 @@
 include_recipe "ark"
 
 ark "chruby" do
-  url "https://github.com/postmodern/chruby/archive/v#{node['chruby']['version']}.tar.gz"
+  url "https://codeload.github.com/postmodern/chruby/tar.gz/v#{node['chruby']['version']}"
+  extension 'tar.gz'
   action :install_with_make
 end
 


### PR DESCRIPTION
Hi,

Recently, when provisioning machines with chruby recipe (chef 11.10.0) you get an error Chef::Exceptions::RedirectLimitExceeded. Looks like GitHub makes redirects to download the actual file and that causes the problem. Not sure if that's absolutely right approach, but providing more direct download URL fixes the issue.

Here's the log from provisioning when the problem appears. Tested on few different OSX machines, different providers (virtualbox, parallels), different days.

[2014-03-23T12:28:57+00:00] INFO: remote_file[/var/chef/cache/chruby-1.tar.gz] created file /var/chef/cache/chruby-1.tar.gz
# 
# Error executing action `create` on resource 'remote_file[/var/chef/cache/chruby-1.tar.gz]'
## Chef::Exceptions::RedirectLimitExceeded

Chef::Exceptions::RedirectLimitExceeded
## Resource Declaration:
# In /tmp/vagrant-chef-1/chef-solo-1/cookbooks/ark/providers/default.rb

265:   remote_file new_resource.release_file do
266:     Chef::Log.debug('DEBUG: new_resource.release_file')
267:     source new_resource.url
268:     checksum new_resource.checksum if new_resource.checksum
269:     action :create
270:     notifies :run, "execute[unpack #{new_resource.release_file}]"
271:   end
272: 
## Compiled Resource:
# Declared in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/ark/providers/default.rb:265:in `block in class_from_file'

remote_file("/var/chef/cache/chruby-1.tar.gz") do
  provider Chef::Provider::RemoteFile
  action [:create]
  retries 0
  retry_delay 2
  path "/var/chef/cache/chruby-1.tar.gz"
  backup 5
  atomic_update true
  source ["https://github.com/postmodern/chruby/archive/v0.3.7.tar.gz"]
  use_etag true
  use_last_modified true
  cookbook_name :chruby
  recipe_name "none"
end

[2014-03-23T12:29:02+00:00] INFO: Running queued delayed notifications before re-raising exception
# 
# Error executing action `install_with_make` on resource 'ark[chruby]'
## Chef::Exceptions::RedirectLimitExceeded

remote_file[/var/chef/cache/chruby-1.tar.gz](chruby::none line 265) had an error: Chef::Exceptions::RedirectLimitExceeded: Chef::Exceptions::RedirectLimitExceeded
## Resource Declaration:
# In /tmp/vagrant-chef-1/chef-solo-1/cookbooks/chruby/recipes/default.rb

 21: ark "chruby" do
 22:   url "https://github.com/postmodern/chruby/archive/v#{node['chruby']['version']}.tar.gz"
 23:   action :install_with_make
 24: end
 25: 
## Compiled Resource:
# Declared in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/chruby/recipes/default.rb:21:in `from_file'

ark("chruby") do
  provider Chef::Provider::Ark
  action [:install_with_make]
  retries 0
  retry_delay 2
  cookbook_name :chruby
  recipe_name "default"
  url "https://github.com/postmodern/chruby/archive/v0.3.7.tar.gz"
  extension "tar.gz"
  prefix_bin "/usr/local/bin"
  version "1"
  path "/usr/local/chruby-1"
  home_dir "/usr/local/chruby"
  release_file "/var/chef/cache/chruby-1.tar.gz"
  strip_leading_dir true
end

[2014-03-23T12:29:02+00:00] INFO: Running queued delayed notifications before re-raising exception
[2014-03-23T12:29:02+00:00] ERROR: Running exception handlers
[2014-03-23T12:29:02+00:00] ERROR: Exception handlers complete
[2014-03-23T12:29:02+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2014-03-23T12:29:02+00:00] ERROR: ark[chruby](chruby::default line 21) had an error: Chef::Exceptions::RedirectLimitExceeded: remote_file[/var/chef/cache/chruby-1.tar.gz](chruby::none line 265) had an error: Chef::Exceptions::RedirectLimitExceeded: Chef::Exceptions::RedirectLimitExceeded
[2014-03-23T12:29:02+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
