### PR TITLE
Use version attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Ensure you set an explicit dependency on the `chruby` cookbook if you are using 
 - `node['chruby']['auto_switch']` - enable automatic switching between Ruby versions per https://github.com/postmodern/chruby#auto-switching
 - `node['chruby']['rubies']` - an hash of Rubies / Booleans values to install using the `ruby-build` LWRP, and make available to chruby.
 - `node['chruby']['default']` - specify the default Ruby version for every shell.
- 
+- `node['chruby']['user_rubies']` - an array of directories containing custom rubies
+
 # Recipes
 
 ## Default
@@ -77,7 +78,7 @@ Builds and makes available the Ruby versions listed in the `node['chruby']['rubi
 
 - Author: Stephen Nelson-Smith (LordCope) - Atalanta Systems Ltd (<cookbooks@atalanta-systems.com>)
 
-Copyright 2013, Atalanta Systems Ltd 
+Copyright 2013, Atalanta Systems Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,6 @@ default['chruby']['use_rbenv_rubies'] = false
 default['chruby']['auto_switch'] = true
 default['chruby']['rubies'] = {'1.9.3-p392' => true}
 default['chruby']['default'] = 'embedded'
-default['chruby']['user_rubies'] = {}
+default['chruby']['user_rubies'] = []
 default['chruby']['sh_dir'] = "/etc/profile.d"
 default['chruby']['sh_name'] = 'chruby.sh'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,3 +6,5 @@ default['chruby']['auto_switch'] = true
 default['chruby']['rubies'] = {'1.9.3-p392' => true}
 default['chruby']['default'] = 'embedded'
 default['chruby']['user_rubies'] = {}
+default['chruby']['sh_dir'] = "/etc/profile.d"
+default['chruby']['sh_name'] = 'chruby.sh'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,14 +26,18 @@ end
 # Workaround for Github issue 5 https://github.com/Atalanta/chef-chruby/issues/5
 
 link "/usr/local/chruby" do
-  to "/usr/local/chruby-1" 
-end 
-
-directory "/etc/profile.d" do
-  recursive true
+  to "/usr/local/chruby-1"
 end
 
-template "/etc/profile.d/chruby.sh" do
+sh_owner = node['chruby']['sh_owner']
+
+directory node['chruby']['sh_dir'] do
+  recursive true
+  owner sh_owner if sh_owner
+end
+
+template File.join(node['chruby']['sh_dir'], node['chruby']['sh_name']) do
   source "chruby.sh.erb"
   mode "0644"
+  owner sh_owner if sh_owner
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,13 +20,14 @@ include_recipe "ark"
 
 ark "chruby" do
   url "https://github.com/postmodern/chruby/archive/v#{node['chruby']['version']}.tar.gz"
+  version node['chruby']['version']
   action :install_with_make
 end
 
 # Workaround for Github issue 5 https://github.com/Atalanta/chef-chruby/issues/5
 
 link "/usr/local/chruby" do
-  to "/usr/local/chruby-1"
+  to "/usr/local/chruby-#{node['chruby']['version']}"
 end
 
 sh_owner = node['chruby']['sh_owner']

--- a/templates/default/chruby.sh.erb
+++ b/templates/default/chruby.sh.erb
@@ -1,5 +1,9 @@
 source /usr/local/chruby/share/chruby/chruby.sh
 
+<% if ::File.exists?("/opt/chefdk/embedded") -%>
+RUBIES+=(/opt/chefdk/embedded)
+<% end -%>
+
 <% if ::File.exists?("/opt/chef/embedded") -%>
 RUBIES+=(/opt/chef/embedded)
 <% end -%>
@@ -16,7 +20,7 @@ RUBIES+=($HOME/.rbenv/rubies/*)
 RUBIES+=(<%= directory.sub(/\/\z/, '') %>/*)
 <% end -%>
 
-<% if ::File.exists?("/opt/chef/embedded") and node['chruby']['default'] == "embedded" -%>
+<% if (::File.exists?("/opt/chef/embedded") or ::File.exists?("/opt/chefdk/embedded")) and node['chruby']['default'] == "embedded" -%>
 chruby embedded
 <% elsif node['chruby']['default'] -%>
 chruby <%= node['chruby']['default'] %>

--- a/templates/default/chruby.sh.erb
+++ b/templates/default/chruby.sh.erb
@@ -12,6 +12,10 @@ RUBIES+=($HOME/.rvm/rubies/*)
 RUBIES+=($HOME/.rbenv/rubies/*)
 <% end -%>
 
+<% node['chruby']['user_rubies'].each do |directory| -%>
+RUBIES+=(<%= directory.sub(/\/\z/, '') %>/*)
+<% end -%>
+
 <% if ::File.exists?("/opt/chef/embedded") and node['chruby']['default'] == "embedded" -%>
 chruby embedded
 <% elsif node['chruby']['default'] -%>


### PR DESCRIPTION
This is less ugly, as it uses a nice version numebr as a prefix for the installation directory, e.g. `/usr/local/chruby-0.3.4`.
This also makes it possible to properly upgrade a version using the `node['chruby']['version']` attribute.
