### PR TITLE
Add ability to specify shell

### DIFF
--- a/templates/default/chruby.sh.erb
+++ b/templates/default/chruby.sh.erb
@@ -1,3 +1,7 @@
+<% if node['chruby']['shell'] -%>
+#!<%= node['chruby']['shell'] -%>
+<% end -%>
+
 source /usr/local/chruby/share/chruby/chruby.sh
 
 <% if ::File.exists?("/opt/chefdk/embedded") -%>


### PR DESCRIPTION
On certain systems that have an odd default shell (ksh, zsh) no shebang line specifying shell can cause shell crash (preventing ssh login and other issues)
