### PR TITLE
Make it possible to specify a checksum for the `ark` resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Ensure you set an explicit dependency on the `chruby` cookbook if you are using 
 # Attributes
 
 - `node['chruby']['version']` - the version of Chruby to install.  Default is 0.3.4.
+- `node['chruby']['checksum']` - the SHA256 checksum of the archive downloaded from github; allows to avoid downloading from Github at every Chef run. Default is `nil` (mainly for backward compatibility with existing wrapper cookbooks)
 - TODO: `node['chruby']['gpg_check']` - run the GPG check to verify the release was not tampered with.
 - `node['chruby']['use_rvm_rubies']` - make Rubies installed using RVM available to chruby.
 - `node['chruby']['use_rbenv_rubies']` - make Rubies installed using Rbenv available to chruby.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default['chruby']['version'] = '0.3.4'
+default['chruby']['checksum'] = nil
 default['chruby']['gpg_check'] = false
 default['chruby']['use_rvm_rubies'] = false
 default['chruby']['use_rbenv_rubies'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,13 +20,15 @@ include_recipe "ark"
 
 ark "chruby" do
   url "https://github.com/postmodern/chruby/archive/v#{node['chruby']['version']}.tar.gz"
+  version node['chruby']['version']
+  checksum node['chruby']['checksum']
   action :install_with_make
 end
 
 # Workaround for Github issue 5 https://github.com/Atalanta/chef-chruby/issues/5
 
 link "/usr/local/chruby" do
-  to "/usr/local/chruby-1"
+  to "/usr/local/chruby-#{node['chruby']['version']}"
 end
 
 sh_owner = node['chruby']['sh_owner']


### PR DESCRIPTION
Which allows to avoid re-downloading the chruby archive from Github at every
single Chef-client run; which, besides being nice to Github, avoids stalling
Chef on nodes running this cookbook when Github is down.

By default though, the `checksum` attribute is set to `nil` (and hence not
used) to maintain backward compatibility with existing wrapper cookbooks.

Also properly setting the `version` attribute of the `ark` resource, mainly for
cosmetic reasons.

Updated the README.
